### PR TITLE
Numerous improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Files downloaded by xnubuild.sh
+/AvailabilityVersions-*/
+/CoreOSMakefiles-*/
+/dtrace-*/
+/libdispatch-*/
+/libplatform-*/
+/xnu-*/
+
+*.tar.gz
+/build/

--- a/patches/availability_versions.patch
+++ b/patches/availability_versions.patch
@@ -1,0 +1,33 @@
+diff --git a/bsd/sys/make_symbol_aliasing.sh b/bsd/sys/make_symbol_aliasing.sh
+index ef47e37..a1e694a 100755
+--- a/bsd/sys/make_symbol_aliasing.sh
++++ b/bsd/sys/make_symbol_aliasing.sh
+@@ -34,8 +34,8 @@ fi
+ SDKROOT="$1"
+ OUTPUT="$2"
+
+-if [ ! -x "${SDKROOT}/usr/local/libexec/availability.pl" ] ; then
+-    echo "Unable to locate ${SDKROOT}/usr/local/libexec/availability.pl (or not executable)" >&2
++if [ ! -x "${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl" ] ; then
++    echo "Unable to locate ${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl (or not executable)" >&2
+     exit 1
+ fi
+
+@@ -74,7 +74,7 @@ cat <<EOF
+
+ EOF
+
+-for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --ios) ; do
++for ver in $(${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl --ios) ; do
+     ver_major=${ver%.*}
+     ver_minor=${ver#*.}
+     value=$(printf "%d%02d00" ${ver_major} ${ver_minor})
+@@ -87,7 +87,7 @@ for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --ios) ; do
+     echo ""
+ done
+
+-for ver in $(${SDKROOT}/usr/local/libexec/availability.pl --macosx) ; do
++for ver in $(${DEPENDENCIES_DIR}/usr/local/libexec/availability.pl --macosx) ; do
+     set -- $(echo "$ver" | tr '.' ' ')
+     ver_major=$1
+     ver_minor=$2

--- a/patches/fix_build.patch
+++ b/patches/fix_build.patch
@@ -1,0 +1,12 @@
+diff --git a/osfmk/i386/cpu_topology.c b/osfmk/i386/cpu_topology.c
+index e079e6e..6f6baf7 100644
+--- a/osfmk/i386/cpu_topology.c
++++ b/osfmk/i386/cpu_topology.c
+@@ -37,6 +37,7 @@
+ #include <i386/cpu_data.h>
+ #include <i386/lapic.h>
+ #include <i386/machine_routines.h>
++#include <stddef.h>
+ 
+ __private_extern__ void qsort(
+     void * array,

--- a/patches/fix_codesigning.patch
+++ b/patches/fix_codesigning.patch
@@ -1,0 +1,91 @@
+diff --git a/SETUP/config/Makefile b/SETUP/config/Makefile
+index 56032b4..1e73452 100644
+--- a/SETUP/config/Makefile
++++ b/SETUP/config/Makefile
+@@ -20,7 +20,7 @@ config: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/decomment/Makefile b/SETUP/decomment/Makefile
+index 7018eb1..877ca15 100644
+--- a/SETUP/decomment/Makefile
++++ b/SETUP/decomment/Makefile
+@@ -18,7 +18,7 @@ decomment: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/installfile/Makefile b/SETUP/installfile/Makefile
+index eb1f3af..a74b483 100644
+--- a/SETUP/installfile/Makefile
++++ b/SETUP/installfile/Makefile
+@@ -18,7 +18,7 @@ installfile: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/json_compilation_db/Makefile b/SETUP/json_compilation_db/Makefile
+index 518644c..bf453c3 100644
+--- a/SETUP/json_compilation_db/Makefile
++++ b/SETUP/json_compilation_db/Makefile
+@@ -18,7 +18,7 @@ json_compilation_db: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/kextsymboltool/Makefile b/SETUP/kextsymboltool/Makefile
+index af6cdca..e38782f 100644
+--- a/SETUP/kextsymboltool/Makefile
++++ b/SETUP/kextsymboltool/Makefile
+@@ -18,7 +18,7 @@ kextsymboltool: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/replacecontents/Makefile b/SETUP/replacecontents/Makefile
+index e1e8484..44b81b9 100644
+--- a/SETUP/replacecontents/Makefile
++++ b/SETUP/replacecontents/Makefile
+@@ -18,7 +18,7 @@ replacecontents: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"
+diff --git a/SETUP/setsegname/Makefile b/SETUP/setsegname/Makefile
+index 7e9224e..c2ed335 100644
+--- a/SETUP/setsegname/Makefile
++++ b/SETUP/setsegname/Makefile
+@@ -18,7 +18,7 @@ setsegname: $(OBJS)
+ 	@echo "$(ColorH)HOST_LD$(Color0)       $(ColorF)$@$(Color0)"
+ 	$(_v)$(HOST_CC) $(LDFLAGS) -o $@ $^
+ 	@echo "$(ColorH)HOST_CODESIGN$(Color0) $(ColorF)$@$(Color0)"
+-	$(_v)env CODESIGN_ALLOCATE=$(HOST_CODESIGN_ALLOCATE) $(HOST_CODESIGN) -s - $@
++	$(_v)env $(HOST_CODESIGN) -s - $@
+ 
+ %.o: %.c
+ 	@echo "$(ColorH)HOST_CC$(Color0)       $(ColorF)$@$(Color0)"

--- a/patches/fix_system_framework.patch
+++ b/patches/fix_system_framework.patch
@@ -1,0 +1,20 @@
+diff --git a/makedefs/MakeInc.kernel b/makedefs/MakeInc.kernel
+index 0885b3f..49c2f1f 100644
+--- a/makedefs/MakeInc.kernel
++++ b/makedefs/MakeInc.kernel
+@@ -281,6 +281,15 @@ do_installhdrs_mi:: $(DSTROOT)/$(KRESDIR)/Info.plist
+ 	$(_v)$(RM) $(DSTROOT)/$(KINCFRAME)/Resources
+ 	$(_v)$(LN) Versions/Current/Resources			\
+ 		   $(DSTROOT)/$(KINCFRAME)/Resources
++	$(_v)$(RM) $(DSTROOT)/$(SINCFRAME)/Versions/Current
++	$(_v)$(LN) $(SINCVERS) \
++		   $(DSTROOT)/$(SINCFRAME)/Versions/Current
++	$(_v)$(RM) $(DSTROOT)/$(SINCFRAME)/PrivateHeaders
++	$(_v)$(LN) Versions/Current/PrivateHeaders		\
++		   $(DSTROOT)/$(SINCFRAME)/PrivateHeaders
++	$(_v)$(RM) $(DSTROOT)/$(SINCFRAME)/Resources
++	$(_v)$(LN) Versions/Current/Resources			\
++		   $(DSTROOT)/$(SINCFRAME)/Resources
+ 
+ $(DSTROOT)/$(KRESDIR)/Info.plist: $(SOURCE)/EXTERNAL_HEADERS/Info.plist
+ 	$(_v)$(MKDIR) $(DSTROOT)/$(KRESDIR)

--- a/patches/kext_copyright_check.patch
+++ b/patches/kext_copyright_check.patch
@@ -1,0 +1,22 @@
+diff --git a/libkern/kxld/kxld_copyright.c b/libkern/kxld/kxld_copyright.c
+index e1f13c2..8664226 100644
+--- a/libkern/kxld/kxld_copyright.c
++++ b/libkern/kxld/kxld_copyright.c
+@@ -49,6 +49,7 @@
+ 
+ #define kCopyrightToken "Copyright © "
+ #define kRightsToken " Apple Inc. All rights reserved."
++#define kRightsTokenPD " PureDarwin Project. All rights reserved."
+ 
+ /******************************************************************************
+ * Globals
+@@ -252,6 +253,9 @@ kxld_validate_copyright_string(const char *str)
+ 
+     copyright = kxld_strstr(str, kCopyrightToken);
+     rights = kxld_strstr(str, kRightsToken);
++    if (!rights) {
++        rights = kxld_strstr(str, kRightsTokenPD);
++    }
+ 
+     if (!copyright || !rights || copyright > rights) goto finish;
+ 

--- a/patches/libfirehose.patch
+++ b/patches/libfirehose.patch
@@ -1,0 +1,13 @@
+diff --git a/xcodeconfig/libfirehose_kernel.xcconfig b/xcodeconfig/libfirehose_kernel.xcconfig
+index c572f80..1c567bd 100644
+--- a/xcodeconfig/libfirehose_kernel.xcconfig
++++ b/xcodeconfig/libfirehose_kernel.xcconfig
+@@ -27,7 +27,7 @@ GCC_PREPROCESSOR_DEFINITIONS = $(inherited) KERNEL=1 DISPATCH_USE_DTRACE=0
+ OTHER_CFLAGS = -mkernel -nostdinc -Wno-packed
+ // LLVM_LTO = YES
+ PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/kernel/os
+-HEADER_SEARCH_PATHS = $(PROJECT_DIR) $(SDKROOT)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(SDKROOT)/System/Library/Frameworks/Kernel.framework/Headers $(SDKROOT)/usr/local/include/os $(SDKROOT)/usr/local/include/firehose
++HEADER_SEARCH_PATHS = $(PROJECT_DIR) $(DEPENDENCIES_DIR)/System/Library/Frameworks/Kernel.framework/PrivateHeaders $(DEPENDENCIES_DIR)/System/Library/Frameworks/Kernel.framework/Headers $(DEPENDENCIES_DIR)/usr/local/include/os $(DEPENDENCIES_DIR)/usr/local/include/firehose
+ 
+ COPY_HEADERS_RUN_UNIFDEF = YES
+ COPY_HEADERS_UNIFDEF_FLAGS = -DKERNEL=1 -DOS_FIREHOSE_SPI=1 -DOS_VOUCHER_ACTIVITY_SPI_TYPES=1 -UOS_VOUCHER_ACTIVITY_SPI

--- a/patches/libsyscall.patch
+++ b/patches/libsyscall.patch
@@ -1,0 +1,177 @@
+Binary files xnu-4570.1.46.org/libsyscall/.DS_Store and xnu-4570.1.46/libsyscall/.DS_Store differ
+diff -rupN xnu-4570.1.46.org/libsyscall/Libsyscall.xcodeproj/project.pbxproj xnu-4570.1.46/libsyscall/Libsyscall.xcodeproj/project.pbxproj
+--- xnu-4570.1.46.org/libsyscall/Libsyscall.xcodeproj/project.pbxproj	2017-07-30 02:24:53.000000000 -0400
++++ xnu-4570.1.46/libsyscall/Libsyscall.xcodeproj/project.pbxproj	2017-10-01 01:51:19.000000000 -0400
+@@ -109,13 +109,6 @@
+ 		2BA88DCC1810A3CE00EB63F6 /* coalition.c in Sources */ = {isa = PBXBuildFile; fileRef = 2BA88DCB1810A3CE00EB63F6 /* coalition.c */; };
+ 		374A36E314748F1300AAF39D /* varargs_wrappers.s in Sources */ = {isa = PBXBuildFile; fileRef = 374A36E214748EE400AAF39D /* varargs_wrappers.s */; };
+ 		3F538F891A659C5600B37EFD /* persona.c in Sources */ = {isa = PBXBuildFile; fileRef = 3F538F881A659C5600B37EFD /* persona.c */; };
+-		401BB71A1BCAE57B005080D3 /* os_channel.c in Sources */ = {isa = PBXBuildFile; fileRef = 401BB7161BCAE539005080D3 /* os_channel.c */; settings = {COMPILER_FLAGS = "-fno-builtin"; }; };
+-		401BB71C1BCAE57B005080D3 /* os_nexus.c in Sources */ = {isa = PBXBuildFile; fileRef = 401BB7181BCAE539005080D3 /* os_nexus.c */; settings = {COMPILER_FLAGS = "-fno-builtin"; }; };
+-		402AF43F1E5CD88600F1A4B9 /* cpu_in_cksum_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 402AF43E1E5CD88100F1A4B9 /* cpu_in_cksum_gen.c */; settings = {COMPILER_FLAGS = "-fno-builtin"; }; };
+-		403C7CEE1E1F4E4400D6FEEF /* os_packet.c in Sources */ = {isa = PBXBuildFile; fileRef = 405FA3381E0C669D007D66EA /* os_packet.c */; settings = {COMPILER_FLAGS = "-fno-builtin"; }; };
+-		406E0B721E4ACD2000295EA3 /* cpu_copy_in_cksum.s in Sources */ = {isa = PBXBuildFile; fileRef = 40DD162F1E4ACCAA003297CC /* cpu_copy_in_cksum.s */; };
+-		409A78321E4EB3E300E0699B /* cpu_in_cksum.s in Sources */ = {isa = PBXBuildFile; fileRef = 409A78301E4EB3D900E0699B /* cpu_in_cksum.s */; };
+-		40DF0F741E5CD7BB0035A864 /* cpu_copy_in_cksum_gen.c in Sources */ = {isa = PBXBuildFile; fileRef = 40DF0F731E5CD7B30035A864 /* cpu_copy_in_cksum_gen.c */; settings = {COMPILER_FLAGS = "-fno-builtin"; }; };
+ 		435F3CAA1B06B7BA005ED9EF /* work_interval.c in Sources */ = {isa = PBXBuildFile; fileRef = 435F3CA91B06B7BA005ED9EF /* work_interval.c */; };
+ 		467DAFD4157E8AF200CE68F0 /* guarded_open_np.c in Sources */ = {isa = PBXBuildFile; fileRef = 467DAFD3157E8AF200CE68F0 /* guarded_open_np.c */; };
+ 		4BDD5F1D1891AB2F004BF300 /* mach_approximate_time.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BDD5F1B1891AB2F004BF300 /* mach_approximate_time.c */; };
+@@ -137,10 +130,6 @@
+ 		978228281B8678DC008385AC /* pselect-darwinext.c in Sources */ = {isa = PBXBuildFile; fileRef = 978228271B8678CB008385AC /* pselect-darwinext.c */; };
+ 		978228291B8678DF008385AC /* pselect-darwinext-cancel.c in Sources */ = {isa = PBXBuildFile; fileRef = 978228261B8678C2008385AC /* pselect-darwinext-cancel.c */; };
+ 		9CCF28271E68E993002EE6CD /* pid_shutdown_networking.c in Sources */ = {isa = PBXBuildFile; fileRef = 9CCF28261E68E993002EE6CD /* pid_shutdown_networking.c */; };
+-		A50845861DDA69AC0041C0E0 /* thread_self_restrict.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */; };
+-		A50845871DDA69C90041C0E0 /* thread_self_restrict.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */; };
+-		A50BD52F1DDA548F006622C8 /* thread_self_restrict.h in Headers */ = {isa = PBXBuildFile; fileRef = A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */; };
+-		A50BD5301DDA5500006622C8 /* thread_self_restrict.h in Headers */ = {isa = PBXBuildFile; fileRef = A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */; };
+ 		A59CB95616669EFB00B064B3 /* stack_logging_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = A59CB95516669DB700B064B3 /* stack_logging_internal.h */; };
+ 		A59CB9581666A1A200B064B3 /* munmap.c in Sources */ = {isa = PBXBuildFile; fileRef = A59CB9571666A1A200B064B3 /* munmap.c */; };
+ 		BA0D9FB1199031AD007E8A73 /* kdebug_trace.c in Sources */ = {isa = PBXBuildFile; fileRef = BA0D9FB0199031AD007E8A73 /* kdebug_trace.c */; };
+@@ -387,7 +376,6 @@
+ 			dstPath = "$(OS_PRIVATE_HEADERS_FOLDER_PATH)";
+ 			dstSubfolderSpec = 0;
+ 			files = (
+-				A50845871DDA69C90041C0E0 /* thread_self_restrict.h in CopyFiles */,
+ 				C9FD8508166D6BD400963B73 /* tsd.h in CopyFiles */,
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 1;
+@@ -398,7 +386,6 @@
+ 			dstPath = "$(OS_PRIVATE_HEADERS_FOLDER_PATH)";
+ 			dstSubfolderSpec = 0;
+ 			files = (
+-				A50845861DDA69AC0041C0E0 /* thread_self_restrict.h in CopyFiles */,
+ 				C9A3D6EB1672AD1000A5CAA3 /* tsd.h in CopyFiles */,
+ 			);
+ 			runOnlyForDeploymentPostprocessing = 1;
+@@ -494,13 +481,6 @@
+ 		374A36E214748EE400AAF39D /* varargs_wrappers.s */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = varargs_wrappers.s; sourceTree = "<group>"; };
+ 		37DDFB7614748713009D3355 /* syscall.map */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = syscall.map; sourceTree = "<group>"; };
+ 		3F538F881A659C5600B37EFD /* persona.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = persona.c; sourceTree = "<group>"; };
+-		401BB7161BCAE539005080D3 /* os_channel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = os_channel.c; path = skywalk/os_channel.c; sourceTree = "<group>"; };
+-		401BB7181BCAE539005080D3 /* os_nexus.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = os_nexus.c; path = skywalk/os_nexus.c; sourceTree = "<group>"; };
+-		402AF43E1E5CD88100F1A4B9 /* cpu_in_cksum_gen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cpu_in_cksum_gen.c; path = skywalk/cpu_in_cksum_gen.c; sourceTree = "<group>"; };
+-		405FA3381E0C669D007D66EA /* os_packet.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = os_packet.c; path = skywalk/os_packet.c; sourceTree = "<group>"; };
+-		409A78301E4EB3D900E0699B /* cpu_in_cksum.s */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; name = cpu_in_cksum.s; path = skywalk/cpu_in_cksum.s; sourceTree = "<group>"; };
+-		40DD162F1E4ACCAA003297CC /* cpu_copy_in_cksum.s */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; name = cpu_copy_in_cksum.s; path = skywalk/cpu_copy_in_cksum.s; sourceTree = "<group>"; };
+-		40DF0F731E5CD7B30035A864 /* cpu_copy_in_cksum_gen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = cpu_copy_in_cksum_gen.c; path = skywalk/cpu_copy_in_cksum_gen.c; sourceTree = "<group>"; };
+ 		435F3CA91B06B7BA005ED9EF /* work_interval.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = work_interval.c; sourceTree = "<group>"; };
+ 		467DAFD3157E8AF200CE68F0 /* guarded_open_np.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = guarded_open_np.c; sourceTree = "<group>"; };
+ 		4BDD5F1B1891AB2F004BF300 /* mach_approximate_time.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mach_approximate_time.c; sourceTree = "<group>"; };
+@@ -518,7 +498,6 @@
+ 		978228261B8678C2008385AC /* pselect-darwinext-cancel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "pselect-darwinext-cancel.c"; sourceTree = "<group>"; };
+ 		978228271B8678CB008385AC /* pselect-darwinext.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "pselect-darwinext.c"; sourceTree = "<group>"; };
+ 		9CCF28261E68E993002EE6CD /* pid_shutdown_networking.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pid_shutdown_networking.c; sourceTree = "<group>"; };
+-		A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread_self_restrict.h; sourceTree = "<group>"; };
+ 		A59CB95516669DB700B064B3 /* stack_logging_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = stack_logging_internal.h; sourceTree = "<group>"; };
+ 		A59CB9571666A1A200B064B3 /* munmap.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = munmap.c; sourceTree = "<group>"; };
+ 		BA0D9FB0199031AD007E8A73 /* kdebug_trace.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kdebug_trace.c; sourceTree = "<group>"; };
+@@ -812,7 +791,6 @@
+ 				C962B16B18DBA2C80031244A /* setpriority.c */,
+ 				C6460B7B182025DF00F73CCA /* sfi.c */,
+ 				24B223B3121DFF12007DAEDE /* sigsuspend-base.c */,
+-				401BB7141BCAE523005080D3 /* skywalk */,
+ 				E4D45C3B16FB20970002AF25 /* spawn */,
+ 				13B598931A142F5900DB2D5A /* stackshot.c */,
+ 				E4D7E55216F8776300F92D8D /* string */,
+@@ -958,20 +936,6 @@
+ 			path = arm64;
+ 			sourceTree = "<group>";
+ 		};
+-		401BB7141BCAE523005080D3 /* skywalk */ = {
+-			isa = PBXGroup;
+-			children = (
+-				405FA3381E0C669D007D66EA /* os_packet.c */,
+-				40DD162F1E4ACCAA003297CC /* cpu_copy_in_cksum.s */,
+-				409A78301E4EB3D900E0699B /* cpu_in_cksum.s */,
+-				40DF0F731E5CD7B30035A864 /* cpu_copy_in_cksum_gen.c */,
+-				402AF43E1E5CD88100F1A4B9 /* cpu_in_cksum_gen.c */,
+-				401BB7161BCAE539005080D3 /* os_channel.c */,
+-				401BB7181BCAE539005080D3 /* os_nexus.c */,
+-			);
+-			name = skywalk;
+-			sourceTree = "<group>";
+-		};
+ 		BA4414B118336D6A00AAE813 /* Generated MIG headers */ = {
+ 			isa = PBXGroup;
+ 			children = (
+@@ -987,7 +951,6 @@
+ 			children = (
+ 				C9C1824F15338C0B00933F23 /* alloc_once.c */,
+ 				C9EE57F51669673D00337E4B /* tsd.h */,
+-				A50BD52E1DDA548F006622C8 /* thread_self_restrict.h */,
+ 			);
+ 			path = os;
+ 			sourceTree = "<group>";
+@@ -1077,7 +1040,6 @@
+ 				C6D3EFBC16542C510052CF30 /* mach_interface.h in Headers */,
+ 				C6D3EFBD16542C510052CF30 /* port_obj.h in Headers */,
+ 				C6D3EFBE16542C510052CF30 /* sync.h in Headers */,
+-				A50BD52F1DDA548F006622C8 /* thread_self_restrict.h in Headers */,
+ 				C6D3EFC116542C510052CF30 /* vm_task.h in Headers */,
+ 				C6D3EFC216542C510052CF30 /* key_defs.h in Headers */,
+ 				C6D3EFC316542C510052CF30 /* ls_defs.h in Headers */,
+@@ -1112,7 +1074,6 @@
+ 				C9D9BD29114B00600000D8B9 /* mach_interface.h in Headers */,
+ 				C9D9BD2B114B00600000D8B9 /* port_obj.h in Headers */,
+ 				C9D9BD2C114B00600000D8B9 /* sync.h in Headers */,
+-				A50BD5301DDA5500006622C8 /* thread_self_restrict.h in Headers */,
+ 				C9D9BD2F114B00600000D8B9 /* vm_task.h in Headers */,
+ 				C9D9BD50114B00600000D8B9 /* key_defs.h in Headers */,
+ 				C9D9BD51114B00600000D8B9 /* ls_defs.h in Headers */,
+@@ -1301,14 +1262,12 @@
+ 			isa = PBXSourcesBuildPhase;
+ 			buildActionMask = 2147483647;
+ 			files = (
+-				403C7CEE1E1F4E4400D6FEEF /* os_packet.c in Sources */,
+ 				E214BDC81C2E358300CEE8A3 /* clonefile.c in Sources */,
+ 				C9D9BD19114B00600000D8B9 /* clock_priv.defs in Sources */,
+ 				C9D9BD1A114B00600000D8B9 /* clock_reply.defs in Sources */,
+ 				C9D9BD1C114B00600000D8B9 /* clock.defs in Sources */,
+ 				C9D9BD22114B00600000D8B9 /* exc.defs in Sources */,
+ 				C9D9BD30114B00600000D8B9 /* host_priv.defs in Sources */,
+-				409A78321E4EB3E300E0699B /* cpu_in_cksum.s in Sources */,
+ 				C9D9BD31114B00600000D8B9 /* host_security.defs in Sources */,
+ 				C9D9BD35114B00600000D8B9 /* lock_set.defs in Sources */,
+ 				C9D9BD38114B00600000D8B9 /* mach_host.defs in Sources */,
+@@ -1389,7 +1348,6 @@
+ 				248BA069121D9E27008C073F /* getrlimit.c in Sources */,
+ 				C6460B7C182025DF00F73CCA /* sfi.c in Sources */,
+ 				248BA080121DA36B008C073F /* ioctl.c in Sources */,
+-				401BB71A1BCAE57B005080D3 /* os_channel.c in Sources */,
+ 				C6BEE9181806840200D25AAB /* posix_sem_obsolete.c in Sources */,
+ 				248BA082121DA4F3008C073F /* kill.c in Sources */,
+ 				248BA085121DA5E4008C073F /* kill.c in Sources */,
+@@ -1411,7 +1369,6 @@
+ 				248BA0BE121DE902008C073F /* select.c in Sources */,
+ 				248BA0CD121DEBEF008C073F /* setrlimit.c in Sources */,
+ 				24B223B0121DFD36007DAEDE /* sigsuspend.c in Sources */,
+-				401BB71C1BCAE57B005080D3 /* os_nexus.c in Sources */,
+ 				24B223B2121DFE6D007DAEDE /* sigsuspend-cancel.c in Sources */,
+ 				E4216C311822D404006F2632 /* mach_voucher.defs in Sources */,
+ 				24B223B5121DFF29007DAEDE /* sigsuspend.c in Sources */,
+@@ -1419,13 +1376,10 @@
+ 				248AA965122C7C330085F5B1 /* rmdir.c in Sources */,
+ 				435F3CAA1B06B7BA005ED9EF /* work_interval.c in Sources */,
+ 				248AA967122C7CDA0085F5B1 /* rename.c in Sources */,
+-				406E0B721E4ACD2000295EA3 /* cpu_copy_in_cksum.s in Sources */,
+ 				24B8C2621237F53900D36CC3 /* remove-counter.c in Sources */,
+ 				C99A4F501305B2BD0054B7B7 /* __get_cpu_capabilities.s in Sources */,
+ 				978228291B8678DF008385AC /* pselect-darwinext-cancel.c in Sources */,
+-				40DF0F741E5CD7BB0035A864 /* cpu_copy_in_cksum_gen.c in Sources */,
+ 				C99A4F531305B43F0054B7B7 /* init_cpu_capabilities.c in Sources */,
+-				402AF43F1E5CD88600F1A4B9 /* cpu_in_cksum_gen.c in Sources */,
+ 				030B179B135377B400DAD1F0 /* open_dprotected_np.c in Sources */,
+ 				E4D45C3116F868ED0002AF25 /* proc_listpidspath.c in Sources */,
+ 				374A36E314748F1300AAF39D /* varargs_wrappers.s in Sources */,
+diff -rupN xnu-4570.1.46.org/libsyscall/Libsyscall.xcodeproj/project.xcworkspace/contents.xcworkspacedata xnu-4570.1.46/libsyscall/Libsyscall.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+--- xnu-4570.1.46.org/libsyscall/Libsyscall.xcodeproj/project.xcworkspace/contents.xcworkspacedata	1969-12-31 19:00:00.000000000 -0500
++++ xnu-4570.1.46/libsyscall/Libsyscall.xcodeproj/project.xcworkspace/contents.xcworkspacedata	2017-10-01 01:50:50.000000000 -0400
+@@ -0,0 +1,7 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<Workspace
++   version = "1.0">
++   <FileRef
++      location = "self:">
++   </FileRef>
++</Workspace>
+Binary files xnu-4570.1.46.org/libsyscall/Libsyscall.xcodeproj/project.xcworkspace/xcuserdata/insane.xcuserdatad/UserInterfaceState.xcuserstate and xnu-4570.1.46/libsyscall/Libsyscall.xcodeproj/project.xcworkspace/xcuserdata/insane.xcuserdatad/UserInterfaceState.xcuserstate differ

--- a/patches/xcode9_warnings.patch
+++ b/patches/xcode9_warnings.patch
@@ -1,8 +1,16 @@
 diff --git a/makedefs/MakeInc.def b/makedefs/MakeInc.def
-index 653af06..f75aefe 100644
+index 8c49bd7..6ba84a4 100644
 --- a/makedefs/MakeInc.def
 +++ b/makedefs/MakeInc.def
-@@ -143,6 +143,7 @@ WARNFLAGS_STD := \
+@@ -130,6 +130,7 @@ WARNFLAGS_STD := \
+ 	-Wfloat-conversion \
+ 	-Wconstant-conversion \
+ 	-Wpointer-bool-conversion \
++	-Wno-cast-qual \
+ 	-Wno-covered-switch-default \
+ 	-Wno-disabled-macro-expansion \
+ 	-Wno-documentation-unknown-command \
+@@ -143,13 +144,15 @@ WARNFLAGS_STD := \
  	-Wno-partial-availability \
  	-Wno-pedantic \
  	-Wno-shift-sign-overflow \
@@ -10,7 +18,16 @@ index 653af06..f75aefe 100644
  	-Wno-switch-enum \
  	-Wno-undef \
  	-Wno-unused-macros \
-@@ -157,7 +158,11 @@ CWARNFLAGS_STD = \
+ 	-Wno-used-but-marked-unused \
+ 	-Wno-variadic-macros \
+ 	-Wno-vla \
+-	-Wno-zero-length-array
++	-Wno-zero-length-array \
++	-Wno-zero-as-null-pointer-constant
+ 
+ CWARNFLAGS_STD = \
+ 	$(WARNFLAGS_STD) \
+@@ -157,7 +160,12 @@ CWARNFLAGS_STD = \
  	-Wmissing-prototypes \
  	-Wshadow \
  	-Winline \
@@ -19,15 +36,20 @@ index 653af06..f75aefe 100644
 +	-Wno-cast-align \
 +	-Wno-format-invalid-specifier \
 +	-Wno-ignored-attributes \
-+	-Wno-strict-prototypes
++	-Wno-strict-prototypes \
++	-Wno-shadow-field
  
  # Can be overridden in Makefile.template or Makefile.$arch
  export CWARNFLAGS ?= $(CWARNFLAGS_STD)
-@@ -170,6 +175,7 @@ CXXWARNFLAGS_STD = \
+@@ -170,8 +178,10 @@ CXXWARNFLAGS_STD = \
  	$(WARNFLAGS_STD) \
  	-Wno-c++98-compat-pedantic \
  	-Wno-exit-time-destructors \
 +	-Wno-ignored-attributes \
  	-Wno-global-constructors \
- 	-Wno-old-style-cast
+-	-Wno-old-style-cast
++	-Wno-old-style-cast \
++	-Wno-inconsistent-missing-destructor-override
  
+ # overloaded-virtual warnings are non-fatal (9000888)
+ CXXWARNFLAGS_STD += -Wno-error=overloaded-virtual

--- a/patches/xcode9_warnings.patch
+++ b/patches/xcode9_warnings.patch
@@ -1,0 +1,33 @@
+diff --git a/makedefs/MakeInc.def b/makedefs/MakeInc.def
+index 653af06..f75aefe 100644
+--- a/makedefs/MakeInc.def
++++ b/makedefs/MakeInc.def
+@@ -143,6 +143,7 @@ WARNFLAGS_STD := \
+ 	-Wno-partial-availability \
+ 	-Wno-pedantic \
+ 	-Wno-shift-sign-overflow \
++	-Wno-strict-prototypes \
+ 	-Wno-switch-enum \
+ 	-Wno-undef \
+ 	-Wno-unused-macros \
+@@ -157,7 +158,11 @@ CWARNFLAGS_STD = \
+ 	-Wmissing-prototypes \
+ 	-Wshadow \
+ 	-Winline \
+-	-Wnested-externs
++	-Wnested-externs \
++	-Wno-cast-align \
++	-Wno-format-invalid-specifier \
++	-Wno-ignored-attributes \
++	-Wno-strict-prototypes
+ 
+ # Can be overridden in Makefile.template or Makefile.$arch
+ export CWARNFLAGS ?= $(CWARNFLAGS_STD)
+@@ -170,6 +175,7 @@ CXXWARNFLAGS_STD = \
+ 	$(WARNFLAGS_STD) \
+ 	-Wno-c++98-compat-pedantic \
+ 	-Wno-exit-time-destructors \
++	-Wno-ignored-attributes \
+ 	-Wno-global-constructors \
+ 	-Wno-old-style-cast
+ 

--- a/patches/xnu_dependencies_dir.patch
+++ b/patches/xnu_dependencies_dir.patch
@@ -1,0 +1,17 @@
+diff --git a/makedefs/MakeInc.cmd b/makedefs/MakeInc.cmd
+index a70a2d8..6e668a5 100644
+--- a/makedefs/MakeInc.cmd
++++ b/makedefs/MakeInc.cmd
+@@ -103,10 +103,10 @@ ifeq ($(DSYMUTIL),)
+ 	export DSYMUTIL := $(shell $(XCRUN) -sdk $(SDKROOT) -find dsymutil)
+ endif
+ ifeq ($(CTFCONVERT),)
+-	export CTFCONVERT := $(shell $(XCRUN) -sdk $(SDKROOT) -find ctfconvert)
++	export CTFCONVERT := $(DEPENDENCIES_DIR)/usr/local/bin/ctfconvert
+ endif
+ ifeq ($(CTFMERGE),)
+-	export CTFMERGE :=  $(shell $(XCRUN) -sdk $(SDKROOT) -find ctfmerge)
++	export CTFMERGE :=  $(DEPENDENCIES_DIR)/usr/local/bin/ctfmerge
+ endif
+ ifeq ($(CTFINSERT),)
+ 	export CTFINSERT := $(shell $(XCRUN) -sdk $(SDKROOT) -find ctf_insert)

--- a/patches/xnu_firehose_dir.patch
+++ b/patches/xnu_firehose_dir.patch
@@ -1,0 +1,22 @@
+iff --git a/makedefs/MakeInc.def b/makedefs/MakeInc.def
+index 4eca357..653af06 100644
+--- a/makedefs/MakeInc.def
++++ b/makedefs/MakeInc.def
+@@ -356,7 +356,7 @@ LDFLAGS_KERNEL_GEN = \
+ 	-Wl,-function_starts \
+ 	-Wl,-headerpad,152
+ 
+-LDFLAGS_KERNEL_SDK	= -L$(SDKROOT)/usr/local/lib/kernel -lfirehose_kernel
++LDFLAGS_KERNEL_SDK	= -L$(DEPENDENCIES_DIR)/usr/local/lib/kernel -lfirehose_kernel
+ 
+ LDFLAGS_KERNEL_RELEASE	=
+ LDFLAGS_KERNEL_DEVELOPMENT     =
+@@ -464,7 +464,7 @@ INCFLAGS_IMPORT	= $(patsubst %, -I$(OBJROOT)/EXPORT_HDRS/%, $(COMPONENT_IMPORT_L
+ INCFLAGS_EXTERN	= -I$(SRCROOT)/EXTERNAL_HEADERS
+ INCFLAGS_GEN	= -I$(SRCROOT)/$(COMPONENT) -I$(OBJROOT)/EXPORT_HDRS/$(COMPONENT)
+ INCFLAGS_LOCAL	= -I.
+-INCFLAGS_SDK	= -I$(SDKROOT)/usr/local/include/kernel
++INCFLAGS_SDK	= -I$(DEPENDENCIES_DIR)/usr/local/include/kernel
+ 
+ INCFLAGS	= $(INCFLAGS_LOCAL) $(INCFLAGS_GEN) $(INCFLAGS_IMPORT) $(INCFLAGS_EXTERN) $(INCFLAGS_MAKEFILE) $(INCFLAGS_SDK)
+ 

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -139,7 +139,7 @@ print "Installing XNU & LibSyscall headers"
 		patch -s -p1 < $PATCH_DIRECTORY/xnu_dependencies_dir.patch && \
 		DEPENDENCIES_DIR=$BUILD_DIR/dependencies make installhdrs SDKROOT=macosx ARCH_CONFIGS=X86_64 SRCROOT=$PWD OBJROOT=$BUILD_DIR/$XNU_VERSION.hdrs.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.hdrs.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.hdrs.dst && \
 		patch -s -p1 < $PATCH_DIRECTORY/libsyscall.patch && \
-		sudo xcodebuild installhdrs -project libsyscall/Libsyscall.xcodeproj -sdk macosx ARCHS='x86_64 i386' SRCROOT=$PWD/libsyscall OBJROOT=$BUILD_DIR/$XNU_VERSION.hdrs.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.hdrs.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.hdrs.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies && \
+		xcodebuild installhdrs -project libsyscall/Libsyscall.xcodeproj -sdk macosx ARCHS='x86_64 i386' SRCROOT=$PWD/libsyscall OBJROOT=$BUILD_DIR/$XNU_VERSION.hdrs.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.hdrs.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.hdrs.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies && \
 		ditto $BUILD_DIR/$XNU_VERSION.hdrs.dst $BUILD_DIR/dependencies
 } || {
 	error "Failed to build XNU & LibSyscall headers"
@@ -162,7 +162,7 @@ print "Setting up libfirehose"
 {
 	mkdir -p $BUILD_DIR/$LIBDISPATCH_VERSION.{obj,sym,dst}
 	cd $SCRIPT_DIRECTORY/$LIBDISPATCH_VERSION && \
-		sudo xcodebuild install -project libdispatch.xcodeproj -target libfirehose_kernel -sdk macosx ARCHS='x86_64 i386' SRCROOT=$PWD OBJROOT=$BUILD_DIR/$LIBDISPATCH_VERSION.obj SYMROOT=$BUILD_DIR/$LIBDISPATCH_VERSION.sym DSTROOT=$BUILD_DIR/$LIBDISPATCH_VERSION.dst ADDITIONAL_SDKS=$BUILD_DIR/dependencies DEPENDENCIES_DIR=$BUILD_DIR/dependencies && \
+		xcodebuild install -project libdispatch.xcodeproj -target libfirehose_kernel -sdk macosx ARCHS='x86_64 i386' SRCROOT=$PWD OBJROOT=$BUILD_DIR/$LIBDISPATCH_VERSION.obj SYMROOT=$BUILD_DIR/$LIBDISPATCH_VERSION.sym DSTROOT=$BUILD_DIR/$LIBDISPATCH_VERSION.dst ADDITIONAL_SDKS=$BUILD_DIR/dependencies DEPENDENCIES_DIR=$BUILD_DIR/dependencies && \
 		ditto $BUILD_DIR/$LIBDISPATCH_VERSION.dst/usr/local $BUILD_DIR/dependencies/usr/local
 } || {
 	error "Failed to setup libfirehose"
@@ -179,7 +179,7 @@ print "Building XNU"
 		patch -s -p1 < $PATCH_DIRECTORY/xnu_firehose_dir.patch && \
 		patch -s -p1 < $PATCH_DIRECTORY/fix_system_framework.patch && \
 		patch -s -p1 < $PATCH_DIRECTORY/xcode9_warnings.patch && \
-		DEPENDENCIES_DIR=$BUILD_DIR/dependencies sudo make SDKROOT=macosx ARCH_CONFIGS=X86_64 KERNEL_CONFIGS=RELEASE OBJROOT=$BUILD_DIR/$XNU_VERSION.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies BUILD_WERROR=0
+		sudo env DEPENDENCIES_DIR=$BUILD_DIR/dependencies make SDKROOT=macosx ARCH_CONFIGS=X86_64 KERNEL_CONFIGS=RELEASE OBJROOT=$BUILD_DIR/$XNU_VERSION.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies BUILD_WERROR=0
 } || {
 	error "Failed to build XNU"
 	exit 1

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -4,7 +4,9 @@ bold=$(tput bold)
 normal=$(tput sgr0)
 error=$(tput bold)$(tput setb 1)$(tput setaf 7)
 
-PATCH_DIRECTORY=$(cd `dirname $0` && pwd)/patches
+SCRIPT_DIRECTORY=$(cd `dirname $0` && pwd)
+PATCH_DIRECTORY=$SCRIPT_DIRECTORY/patches
+BUILD_DIR=$SCRIPT_DIRECTORY/build
 
 print() {
 	echo "${bold}[$(date +"%T")]${normal} $1"
@@ -43,7 +45,6 @@ print "Getting the latest versions"
 
 
 SDK_ROOT=`xcodebuild -version -sdk macosx Path`
-BUILD_DIR=~/Desktop/xnubuild
 
 # Wait for user input
 function wait_enter {
@@ -58,16 +59,6 @@ print "${normal}AvailabilityVersions version:${bold} $AVAILABILITYVERSIONS_VERSI
 print "${normal}libplatform version:${bold} $LIBPLATFORM_VERISON"
 print "${normal}CoreOSMakefiles version:${bold} $COREOSMAKEFILES_VERISON${normal}"
 
-wait_enter
-
-print "Going to temporary build directory ($BUILD_DIR)"
-{
-	mkdir -p $BUILD_DIR
-	cd $BUILD_DIR
-} || {
-	error "Failed to make build directory"
-	exit 1
-}
 wait_enter
 
 # Curl these files from Opensource.apple.com

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -13,7 +13,7 @@ print() {
 }
 
 error() {
-	echo "${error}[$(date +"%T")] $1"
+	echo "${error}[$(date +"%T")] $1${normal}"
 	exit
 }
 

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -88,6 +88,7 @@ print "Extracting dependencies"
 }
 wait_enter
 
+if [ ! -f /Applications/Xcode.app/Contents/Developer/Makefiles/CoreOS/Xcode/BSD.xcconfig ]; then
 print "Installing CoreOSMakefiles"
 {
 	cd $SCRIPT_DIRECTORY/$COREOSMAKEFILES_VERISON && \
@@ -97,6 +98,7 @@ print "Installing CoreOSMakefiles"
 	exit 1
 }
 wait_enter
+fi
 
 mkdir -p $BUILD_DIR/dependencies
 print "Building dtrace"

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -88,22 +88,21 @@ wait_enter
 
 print "Installing CoreOSMakefiles"
 {
-	cd $COREOSMAKEFILES_VERISON && \
-		sudo ditto $PWD/Xcode /Applications/Xcode.app/Contents/Developer/Makefiles/CoreOS/Xcode && \
-	cd ..
+	cd $SCRIPT_DIRECTORY/$COREOSMAKEFILES_VERISON && \
+		sudo ditto $PWD/Xcode /Applications/Xcode.app/Contents/Developer/Makefiles/CoreOS/Xcode
 } || {
 	error "Failed to install CoreOSMakefiles"
 	exit 1
 }
 wait_enter
 
+mkdir -p $BUILD_DIR/dependencies
 print "Building dtrace"
 {
-	cd $DTRACE_VERSION && \
-		mkdir -p obj sym dst && \
-		xcodebuild install -target ctfconvert -target ctfdump -target ctfmerge ARCHS="x86_64" SRCROOT=$PWD OBJROOT=$PWD/obj SYMROOT=$PWD/sym DSTROOT=$PWD/dst && \
-		sudo ditto $PWD/dst/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain && \
-	cd ..
+	mkdir -p $BUILD_DIR/$DTRACE_VERSION.{obj,sym,dst}
+	cd $SCRIPT_DIRECTORY/$DTRACE_VERSION && \
+		xcodebuild install -target ctfconvert -target ctfdump -target ctfmerge ARCHS="x86_64" SRCROOT=$PWD OBJROOT=$BUILD_DIR/$DTRACE_VERSION.obj SYMROOT=$BUILD_DIR/$DTRACE_VERSION.sym DSTROOT=$BUILD_DIR/$DTRACE_VERSION.dst && \
+		ditto $BUILD_DIR/$DTRACE_VERSION.dst/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain $BUILD_DIR/dependencies
 } || {
 	error "Failed to build dtrace"
 	exit 1
@@ -112,11 +111,10 @@ wait_enter
 
 print "Building AvailabilityVersions"
 {
-	cd $AVAILABILITYVERSIONS_VERSION && \
-		mkdir -p dst && \
-		make install SRCROOT=$PWD DSTROOT=$PWD/dst && \
-		sudo ditto $PWD/dst/usr/local `xcrun -sdk macosx -show-sdk-path`/usr/local && \
-	cd ..
+	mkdir -p $BUILD_DIR/$AVAILABILITYVERSIONS_VERSION.dst
+	cd $SCRIPT_DIRECTORY/$AVAILABILITYVERSIONS_VERSION && \
+		make install SRCROOT=$PWD DSTROOT=$BUILD_DIR/$AVAILABILITYVERSIONS_VERSION.dst && \
+		ditto $BUILD_DIR/$AVAILABILITYVERSIONS_VERSION.dst/usr/local $BUILD_DIR/dependencies/usr/local
 } || {
 	error "Failed to build AvailabiltyVersions"
 	exit 1
@@ -126,13 +124,15 @@ wait_enter
 # Install XNU headers
 print "Installing XNU & LibSyscall headers"
 {
-	cd $XNU_VERSION/ && \
-		mkdir -p BUILD.hdrs/obj BUILD.hdrs/sym BUILD.hdrs/dst && \
-		make installhdrs SDKROOT=macosx ARCH_CONFIGS=X86_64 SRCROOT=$PWD OBJROOT=$PWD/BUILD.hdrs/obj SYMROOT=$PWD/BUILD.hdrs/sym DSTROOT=$PWD/BUILD.hdrs/dst && \
-		patch -s -p1 < $PATCH_DIRECTORY/libsyscall.patch && \
-		sudo xcodebuild installhdrs -project libsyscall/Libsyscall.xcodeproj -sdk macosx ARCHS='x86_64 i386' SRCROOT=$PWD/libsyscall OBJROOT=$PWD/BUILD.hdrs/obj SYMROOT=$PWD/BUILD.hdrs/sym DSTROOT=$PWD/BUILD.hdrs/dst && \
-		sudo ditto BUILD.hdrs/dst `xcrun -sdk macosx -show-sdk-path` && \
-	cd ..
+	mkdir -p $BUILD_DIR/$XNU_VERSION.hdrs.{obj,sym,dst}
+	cd $SCRIPT_DIRECTORY/$XNU_VERSION && \
+		patch -p1 < $PATCH_DIRECTORY/availability_versions.patch && \
+		patch -p1 < $PATCH_DIRECTORY/fix_codesigning.patch && \
+		patch -p1 < $PATCH_DIRECTORY/xnu_dependencies_dir.patch && \
+		DEPENDENCIES_DIR=$BUILD_DIR/dependencies make installhdrs SDKROOT=macosx ARCH_CONFIGS=X86_64 SRCROOT=$PWD OBJROOT=$BUILD_DIR/$XNU_VERSION.hdrs.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.hdrs.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.hdrs.dst && \
+		patch -p1 < $PATCH_DIRECTORY/libsyscall.patch && \
+		sudo xcodebuild installhdrs -project libsyscall/Libsyscall.xcodeproj -sdk macosx ARCHS='x86_64 i386' SRCROOT=$PWD/libsyscall OBJROOT=$BUILD_DIR/$XNU_VERSION.hdrs.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.hdrs.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.hdrs.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies && \
+		ditto $BUILD_DIR/$XNU_VERSION.hdrs.dst $BUILD_DIR/dependencies
 } || {
 	error "Failed to build XNU & LibSyscall headers"
 	exit 1
@@ -141,10 +141,9 @@ wait_enter
 
 print "Setting up libplatform"
 {
-	cd $LIBPLATFORM_VERISON && \
-		sudo ditto $PWD/include `xcrun -sdk macosx -show-sdk-path`/usr/local/include && \
-		sudo ditto $PWD/private `xcrun -sdk macosx -show-sdk-path`/usr/local/include && \
-	cd ..
+	cd $SCRIPT_DIRECTORY/$LIBPLATFORM_VERISON && \
+		ditto $PWD/include $BUILD_DIR/dependencies/usr/local/include && \
+		ditto $PWD/private $BUILD_DIR/dependencies/usr/local/include
 } || {
 	error "Failed to setup libplatform"
 	exit 1
@@ -153,11 +152,10 @@ wait_enter
 
 print "Setting up libfirehose"
 {
-	cd $LIBDISPATCH_VERSION && \
-		mkdir -p BUILD.hdrs/obj BUILD.hdrs/sym BUILD.hdrs/dst && \
-		sudo xcodebuild install -project libdispatch.xcodeproj -target libfirehose_kernel -sdk macosx ARCHS='x86_64 i386' SRCROOT=$PWD OBJROOT=$PWD/obj SYMROOT=$PWD/sym DSTROOT=$PWD/dst && \
-		sudo ditto $PWD/dst/usr/local `xcrun -sdk macosx -show-sdk-path`/usr/local && \
-	cd ..
+	mkdir -p $BUILD_DIR/$LIBDISPATCH_VERSION.{obj,sym,dst}
+	cd $SCRIPT_DIRECTORY/$LIBDISPATCH_VERSION && \
+		sudo xcodebuild install -project libdispatch.xcodeproj -target libfirehose_kernel -sdk macosx ARCHS='x86_64 i386' SRCROOT=$PWD OBJROOT=$BUILD_DIR/$LIBDISPATCH_VERSION.obj SYMROOT=$BUILD_DIR/$LIBDISPATCH_VERSION.sym DSTROOT=$BUILD_DIR/$LIBDISPATCH_VERSION.dst ADDITIONAL_SDKS=$BUILD_DIR/dependencies DEPENDENCIES_DIR=$BUILD_DIR/dependencies && \
+		ditto $BUILD_DIR/$LIBDISPATCH_VERSION.dst/usr/local $BUILD_DIR/dependencies/usr/local
 } || {
 	error "Failed to setup libfirehose"
 	exit 1
@@ -167,9 +165,13 @@ wait_enter
 # Building XNU
 print "Building XNU"
 {
-	cd $XNU_VERSION && \
-		sudo make SDKROOT=macosx ARCH_CONFIGS=X86_64 KERNEL_CONFIGS=RELEASE && \
-	cd ..
+	mkdir -p $BUILD_DIR/$XNU_VERSION.{obj,sym,dst}
+	cd $SCRIPT_DIRECTORY/$XNU_VERSION && \
+		patch -p1 < $PATCH_DIRECTORY/kext_copyright_check.patch && \
+		patch -p1 < $PATCH_DIRECTORY/xnu_firehose_dir.patch && \
+		patch -p1 < $PATCH_DIRECTORY/fix_system_framework.patch && \
+		patch -p1 < $PATCH_DIRECTORY/xcode9_warnings.patch && \
+		DEPENDENCIES_DIR=$BUILD_DIR/dependencies sudo make SDKROOT=macosx ARCH_CONFIGS=X86_64 KERNEL_CONFIGS=RELEASE OBJROOT=$BUILD_DIR/$XNU_VERSION.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies
 } || {
 	error "Failed to build XNU"
 	exit 1

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -179,6 +179,7 @@ print "Building XNU"
 		patch -s -p1 < $PATCH_DIRECTORY/xnu_firehose_dir.patch && \
 		patch -s -p1 < $PATCH_DIRECTORY/fix_system_framework.patch && \
 		patch -s -p1 < $PATCH_DIRECTORY/xcode9_warnings.patch && \
+		patch -s -p1 < $PATCH_DIRECTORY/fix_build.patch && \
 		sudo env DEPENDENCIES_DIR=$BUILD_DIR/dependencies make SDKROOT=macosx ARCH_CONFIGS=X86_64 KERNEL_CONFIGS=RELEASE OBJROOT=$BUILD_DIR/$XNU_VERSION.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies BUILD_WERROR=0
 } || {
 	error "Failed to build XNU"

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -175,7 +175,7 @@ print "Building XNU"
 		patch -p1 < $PATCH_DIRECTORY/xnu_firehose_dir.patch && \
 		patch -p1 < $PATCH_DIRECTORY/fix_system_framework.patch && \
 		patch -p1 < $PATCH_DIRECTORY/xcode9_warnings.patch && \
-		DEPENDENCIES_DIR=$BUILD_DIR/dependencies sudo make SDKROOT=macosx ARCH_CONFIGS=X86_64 KERNEL_CONFIGS=RELEASE OBJROOT=$BUILD_DIR/$XNU_VERSION.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies
+		DEPENDENCIES_DIR=$BUILD_DIR/dependencies sudo make SDKROOT=macosx ARCH_CONFIGS=X86_64 KERNEL_CONFIGS=RELEASE OBJROOT=$BUILD_DIR/$XNU_VERSION.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies BUILD_WERROR=0
 } || {
 	error "Failed to build XNU"
 	exit 1

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -130,11 +130,11 @@ print "Installing XNU & LibSyscall headers"
 {
 	mkdir -p $BUILD_DIR/$XNU_VERSION.hdrs.{obj,sym,dst}
 	cd $SCRIPT_DIRECTORY/$XNU_VERSION && \
-		patch -p1 < $PATCH_DIRECTORY/availability_versions.patch && \
-		patch -p1 < $PATCH_DIRECTORY/fix_codesigning.patch && \
-		patch -p1 < $PATCH_DIRECTORY/xnu_dependencies_dir.patch && \
+		patch -s -p1 < $PATCH_DIRECTORY/availability_versions.patch && \
+		patch -s -p1 < $PATCH_DIRECTORY/fix_codesigning.patch && \
+		patch -s -p1 < $PATCH_DIRECTORY/xnu_dependencies_dir.patch && \
 		DEPENDENCIES_DIR=$BUILD_DIR/dependencies make installhdrs SDKROOT=macosx ARCH_CONFIGS=X86_64 SRCROOT=$PWD OBJROOT=$BUILD_DIR/$XNU_VERSION.hdrs.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.hdrs.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.hdrs.dst && \
-		patch -p1 < $PATCH_DIRECTORY/libsyscall.patch && \
+		patch -s -p1 < $PATCH_DIRECTORY/libsyscall.patch && \
 		sudo xcodebuild installhdrs -project libsyscall/Libsyscall.xcodeproj -sdk macosx ARCHS='x86_64 i386' SRCROOT=$PWD/libsyscall OBJROOT=$BUILD_DIR/$XNU_VERSION.hdrs.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.hdrs.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.hdrs.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies && \
 		ditto $BUILD_DIR/$XNU_VERSION.hdrs.dst $BUILD_DIR/dependencies
 } || {
@@ -171,10 +171,10 @@ print "Building XNU"
 {
 	mkdir -p $BUILD_DIR/$XNU_VERSION.{obj,sym,dst}
 	cd $SCRIPT_DIRECTORY/$XNU_VERSION && \
-		patch -p1 < $PATCH_DIRECTORY/kext_copyright_check.patch && \
-		patch -p1 < $PATCH_DIRECTORY/xnu_firehose_dir.patch && \
-		patch -p1 < $PATCH_DIRECTORY/fix_system_framework.patch && \
-		patch -p1 < $PATCH_DIRECTORY/xcode9_warnings.patch && \
+		patch -s -p1 < $PATCH_DIRECTORY/kext_copyright_check.patch && \
+		patch -s -p1 < $PATCH_DIRECTORY/xnu_firehose_dir.patch && \
+		patch -s -p1 < $PATCH_DIRECTORY/fix_system_framework.patch && \
+		patch -s -p1 < $PATCH_DIRECTORY/xcode9_warnings.patch && \
 		DEPENDENCIES_DIR=$BUILD_DIR/dependencies sudo make SDKROOT=macosx ARCH_CONFIGS=X86_64 KERNEL_CONFIGS=RELEASE OBJROOT=$BUILD_DIR/$XNU_VERSION.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies BUILD_WERROR=0
 } || {
 	error "Failed to build XNU"

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -180,7 +180,7 @@ print "Building XNU"
 		patch -s -p1 < $PATCH_DIRECTORY/fix_system_framework.patch && \
 		patch -s -p1 < $PATCH_DIRECTORY/xcode9_warnings.patch && \
 		patch -s -p1 < $PATCH_DIRECTORY/fix_build.patch && \
-		sudo env DEPENDENCIES_DIR=$BUILD_DIR/dependencies make SDKROOT=macosx ARCH_CONFIGS=X86_64 KERNEL_CONFIGS=RELEASE OBJROOT=$BUILD_DIR/$XNU_VERSION.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies BUILD_WERROR=0
+		sudo env DEPENDENCIES_DIR=$BUILD_DIR/dependencies make install SDKROOT=macosx ARCH_CONFIGS=X86_64 KERNEL_CONFIGS=RELEASE OBJROOT=$BUILD_DIR/$XNU_VERSION.obj SYMROOT=$BUILD_DIR/$XNU_VERSION.sym DSTROOT=$BUILD_DIR/$XNU_VERSION.dst DEPENDENCIES_DIR=$BUILD_DIR/dependencies BUILD_WERROR=0
 } || {
 	error "Failed to build XNU"
 	exit 1

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -64,6 +64,7 @@ wait_enter
 # Curl these files from Opensource.apple.com
 print "Getting dependencies from Apple"
 {
+	cd $SCRIPT_DIRECTORY && \
 	curl -O https://opensource.apple.com/tarballs/dtrace/$DTRACE_VERSION.tar.gz && \
 	curl -O https://opensource.apple.com/tarballs/AvailabilityVersions/$AVAILABILITYVERSIONS_VERSION.tar.gz && \
 	curl -O https://opensource.apple.com/tarballs/xnu/$XNU_VERSION.tar.gz && \
@@ -79,6 +80,7 @@ wait_enter
 # Run this command to untar all downloaded files and rm the tar.gz files
 print "Extracting dependencies"
 {
+	cd $SCRIPT_DIRECTORY && \
 	for file in *.tar.gz; do tar -zxf $file; done && rm -f *.tar.gz
 } || {
 	error "Failed to extract dependencies"

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -81,7 +81,11 @@ wait_enter
 print "Extracting dependencies"
 {
 	cd $SCRIPT_DIRECTORY && \
-	for file in *.tar.gz; do tar -zxf $file; done && rm -f *.tar.gz
+	for file in *.tar.gz; do
+		rm -rf $(basename $file .tar.gz)
+		tar -zxf $file
+	done && \
+	rm -f *.tar.gz
 } || {
 	error "Failed to extract dependencies"
 	exit 1

--- a/xnubuild.sh
+++ b/xnubuild.sh
@@ -187,5 +187,4 @@ print "Building XNU"
 
 print "Complete"
 
-cd $BUILD_DIR/$XNU_VERSION/BUILD/obj/RELEASE_X86_64
-open .
+open $BUILD_DIR/$XNU_VERSION.dst


### PR DESCRIPTION
This PR includes numerous changes:

* It now installs XNU into a directory suitable for use with `darwinup`, instead of just building it.
* All patches from darwinbuild are included, in addition to the patch in the original script.
* All building occurs within subdirectories of the `xnubuild` working copy, instead of on the Desktop. (An appropriate gitignore is provided.)
* Reduced use of sudo to the bare minimum (i.e., only the final `make install` on xnu proper uses sudo). `BSD.xcconfig` must still be installed with sudo, but I added a check to skip that step if the file is already present.

Note that I did not add a license to this repository, despite the fact that it currently lacks one. @csekel might want to do that. Thanks!