### PR TITLE
Fix libsyscall build

### DIFF
--- a/patches/xnu/libsyscall-build.patch
+++ b/patches/xnu/libsyscall-build.patch
@@ -14,7 +14,7 @@ index 1055719..92392c9 100644
  CODE_SIGN_IDENTITY = -
  DYLIB_CURRENT_VERSION = $(RC_ProjectSourceVersion)
 -DYLIB_LDFLAGS = -umbrella System -all_load -lCrashReporterClient
-+DYLIB_LDFLAGS = -umbrella System
++DYLIB_LDFLAGS = -umbrella System -all_load
  DYLIB_LDFLAGS[sdk=iphoneos*] = $(inherited) -Wl,-sectalign,__DATA,__data,1000
  DYLIB_LDFLAGS[sdk=watchos*] = $(inherited) -Wl,-sectalign,__DATA,__data,1000
  DYLIB_LDFLAGS[sdk=tvos*] = $(inherited) -Wl,-sectalign,__DATA,__data,1000


### PR DESCRIPTION
Without this patch, the `libsystem_kernel.dylib` output by xnubuild would be missing numerous symbols and therefore be unusable.